### PR TITLE
Fix broken link to sidekiq_workflows in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Why yet another Sidekiq workflow library?
 
-[`easymarketing/sidekiq_workflows`](https://github.com/easymarketing/sidekiq_workflows])
+[`easymarketing/sidekiq_workflows`](https://github.com/easymarketing/sidekiq_workflows)
 is only usable with [Sidekiq Pro](https://sidekiq.org/products/pro.html)
 
 [`chaps-io/gush`](https://github.com/chaps-io/gush) move from Sidekiq to


### PR DESCRIPTION
Just want to say thanks to the contributor of this gem. 
This PR fixes a minor broken link in the README file.
The README file is a bit short, should we add more information so that those who are seeking for `sidekiq_workflows` and `gush` may find this gem if they are not sidekiq pro user or can't upgrade their project due to gem version restriction in `gush`?